### PR TITLE
style(Linters): ran app wide linting

### DIFF
--- a/config/schema/i18n.sql
+++ b/config/schema/i18n.sql
@@ -1,18 +1,20 @@
-# Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+#
+Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
 #
 # Licensed under The MIT License
 # For full copyright and license information, please see the LICENSE.txt
 # Redistributions of files must retain the above copyright notice.
 # MIT License (https://opensource.org/licenses/mit-license.php)
 
-CREATE TABLE i18n (
-    id int NOT NULL auto_increment,
-    locale varchar(6) NOT NULL,
-    model varchar(255) NOT NULL,
+CREATE TABLE i18n
+(
+    id          int          NOT NULL auto_increment,
+    locale      varchar(6)   NOT NULL,
+    model       varchar(255) NOT NULL,
     foreign_key int(10) NOT NULL,
-    field varchar(255) NOT NULL,
-    content text,
+    field       varchar(255) NOT NULL,
+    content     text,
     PRIMARY KEY (id),
     UNIQUE INDEX I18N_LOCALE_FIELD(locale, model, foreign_key, field),
-    INDEX I18N_FIELD(model, foreign_key, field)
+    INDEX       I18N_FIELD(model, foreign_key, field)
 );

--- a/config/schema/sessions.sql
+++ b/config/schema/sessions.sql
@@ -1,15 +1,17 @@
-# Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+#
+Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
 #
 # Licensed under The MIT License
 # For full copyright and license information, please see the LICENSE.txt
 # Redistributions of files must retain the above copyright notice.
 # MIT License (https://opensource.org/licenses/mit-license.php)
 
-CREATE TABLE `sessions` (
-  `id` char(40) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
-  `created` datetime DEFAULT CURRENT_TIMESTAMP, -- optional, requires MySQL 5.6.5+
-  `modified` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, -- optional, requires MySQL 5.6.5+
-  `data` blob DEFAULT NULL, -- for PostgreSQL use bytea instead of blob
-  `expires` int(10) unsigned DEFAULT NULL,
-  PRIMARY KEY (`id`)
+CREATE TABLE `sessions`
+(
+    `id`       char(40) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    `created`  datetime DEFAULT CURRENT_TIMESTAMP,                             -- optional, requires MySQL 5.6.5+
+    `modified` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, -- optional, requires MySQL 5.6.5+
+    `data`     blob     DEFAULT NULL,                                          -- for PostgreSQL use bytea instead of blob
+    `expires`  int(10) unsigned DEFAULT NULL,
+    PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/plugins/CustomBake/phpunit.xml.dist
+++ b/plugins/CustomBake/phpunit.xml.dist
@@ -4,7 +4,7 @@
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="tests/bootstrap.php"
-    >
+>
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
@@ -19,7 +19,7 @@
 
     <!-- Setup fixture extension -->
     <extensions>
-        <extension class="Cake\TestSuite\Fixture\PHPUnitExtension" />
+        <extension class="Cake\TestSuite\Fixture\PHPUnitExtension"/>
     </extensions>
 
     <filter>

--- a/plugins/CustomBake/src/CustomBakePlugin.php
+++ b/plugins/CustomBake/src/CustomBakePlugin.php
@@ -21,7 +21,7 @@ class CustomBakePlugin extends BasePlugin
      * The host application is provided as an argument. This allows you to load
      * additional plugin dependencies, or attach events.
      *
-     * @param \Cake\Core\PluginApplicationInterface $app The host application
+     * @param PluginApplicationInterface $app The host application
      * @return void
      */
     public function bootstrap(PluginApplicationInterface $app): void
@@ -34,7 +34,7 @@ class CustomBakePlugin extends BasePlugin
      * If your plugin has many routes and you would like to isolate them into a separate file,
      * you can create `$plugin/config/routes.php` and delete this method.
      *
-     * @param \Cake\Routing\RouteBuilder $routes The route builder to update.
+     * @param RouteBuilder $routes The route builder to update.
      * @return void
      */
     public function routes(RouteBuilder $routes): void
@@ -54,8 +54,8 @@ class CustomBakePlugin extends BasePlugin
     /**
      * Add middleware for the plugin.
      *
-     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to update.
-     * @return \Cake\Http\MiddlewareQueue
+     * @param MiddlewareQueue $middlewareQueue The middleware queue to update.
+     * @return MiddlewareQueue
      */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
@@ -67,8 +67,8 @@ class CustomBakePlugin extends BasePlugin
     /**
      * Add commands for the plugin.
      *
-     * @param \Cake\Console\CommandCollection $commands The command collection to update.
-     * @return \Cake\Console\CommandCollection
+     * @param CommandCollection $commands The command collection to update.
+     * @return CommandCollection
      */
     public function console(CommandCollection $commands): CommandCollection
     {
@@ -82,7 +82,7 @@ class CustomBakePlugin extends BasePlugin
     /**
      * Register application container services.
      *
-     * @param \Cake\Core\ContainerInterface $container The Container to update.
+     * @param ContainerInterface $container The Container to update.
      * @return void
      * @link https://book.cakephp.org/4/en/development/dependency-injection.html#dependency-injection
      */

--- a/plugins/CustomBake/tests/bootstrap.php
+++ b/plugins/CustomBake/tests/bootstrap.php
@@ -49,6 +49,7 @@ if (file_exists($root . '/config/bootstrap.php')) {
  * using migrations to provide schema for your plugin,
  * and using \Migrations\TestSuite\Migrator to load schema.
  */
+
 use Cake\TestSuite\Fixture\SchemaLoader;
 
 // Load a schema dump file.

--- a/templates/Error/error400.php
+++ b/templates/Error/error400.php
@@ -5,6 +5,7 @@
  * @var string $message
  * @var string $url
  */
+
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
@@ -17,19 +18,19 @@ if (Configure::read('debug')) :
     $this->assign('templateName', 'error400.php');
 
     $this->start('file');
-?>
-<?php if (!empty($error->queryString)) : ?>
+    ?>
+    <?php if (!empty($error->queryString)) : ?>
     <p class="notice">
         <strong>SQL Query: </strong>
         <?= h($error->queryString) ?>
     </p>
-<?php endif; ?>
-<?php if (!empty($error->params)) : ?>
+    <?php endif; ?>
+    <?php if (!empty($error->params)) : ?>
     <strong>SQL Query Params: </strong>
-    <?php Debugger::dump($error->params) ?>
-<?php endif; ?>
+        <?php Debugger::dump($error->params) ?>
+    <?php endif; ?>
 
-<?php
+    <?php
     echo $this->element('auto_table_warning');
 
     $this->end();

--- a/templates/Error/error500.php
+++ b/templates/Error/error500.php
@@ -5,6 +5,7 @@
  * @var string $message
  * @var string $url
  */
+
 use Cake\Core\Configure;
 use Cake\Error\Debugger;
 
@@ -17,24 +18,24 @@ if (Configure::read('debug')) :
     $this->assign('templateName', 'error500.php');
 
     $this->start('file');
-?>
-<?php if (!empty($error->queryString)) : ?>
+    ?>
+    <?php if (!empty($error->queryString)) : ?>
     <p class="notice">
         <strong>SQL Query: </strong>
         <?= h($error->queryString) ?>
     </p>
-<?php endif; ?>
-<?php if (!empty($error->params)) : ?>
+    <?php endif; ?>
+    <?php if (!empty($error->params)) : ?>
     <strong>SQL Query Params: </strong>
-    <?php Debugger::dump($error->params) ?>
-<?php endif; ?>
-<?php if ($error instanceof Error) : ?>
-    <?php $file = $error->getFile() ?>
-    <?php $line = $error->getLine() ?>
+        <?php Debugger::dump($error->params) ?>
+    <?php endif; ?>
+    <?php if ($error instanceof Error) : ?>
+        <?php $file = $error->getFile() ?>
+        <?php $line = $error->getLine() ?>
     <strong>Error in: </strong>
-    <?= $this->Html->link(sprintf('%s, line %s', Debugger::trimPath($file), $line), Debugger::editorUrl($file, $line)); ?>
-<?php endif; ?>
-<?php
+        <?= $this->Html->link(sprintf('%s, line %s', Debugger::trimPath($file), $line), Debugger::editorUrl($file, $line)); ?>
+    <?php endif; ?>
+    <?php
     echo $this->element('auto_table_warning');
 
     $this->end();

--- a/templates/Pages/home_old.php
+++ b/templates/Pages/home_old.php
@@ -11,8 +11,10 @@
  * @link      https://cakephp.org CakePHP(tm) Project
  * @since     0.10.0
  * @license   https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var AppView $this
  */
+
+use App\View\AppView;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -40,7 +42,7 @@ $checkConnection = function (string $name) {
             $error = 'Try adding your current <b>top level domain</b> to the
                 <a href="https://book.cakephp.org/debugkit/4/en/index.html#configuration" target="_blank">DebugKit.safeTld</a>
             config and reload.';
-            if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+            if (!in_array('sqlite', PDO::getAvailableDrivers())) {
                 $error .= '<br />You need to install the PHP extension <code>pdo_sqlite</code> so DebugKit can work properly.';
             }
         }
@@ -74,50 +76,62 @@ endif;
     <?= $this->fetch('script') ?>
 </head>
 <body>
-    <header>
-        <div class="container text-center">
-            <a href="https://cakephp.org/" target="_blank" rel="noopener">
-                <img alt="CakePHP" src="https://cakephp.org/v2/img/logos/CakePHP_Logo.svg" width="350" />
-            </a>
-            <h1>
-                Welcome to CakePHP <?= h(Configure::version()) ?> Strawberry (🍓)
-            </h1>
-        </div>
-    </header>
-    <main class="main">
-        <div class="container">
-            <div class="content">
-                <div class="row">
-                    <div class="column">
-                        <div class="message default text-center">
-                            <small>Please be aware that this page will not be shown if you turn off debug mode unless you replace templates/Pages/home.php with your own version.</small>
-                        </div>
-                        <div id="url-rewriting-warning" style="padding: 1rem; background: #fcebea; color: #cc1f1a; border-color: #ef5753;">
-                            <ul>
-                                <li class="bullet problem">
-                                    URL rewriting is not properly configured on your server.<br />
-                                    1) <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/installation.html#url-rewriting">Help me configure it</a><br />
-                                    2) <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/development/configuration.html#general-configuration">I don't / can't use URL rewriting</a>
-                                </li>
-                            </ul>
-                        </div>
-                        <?php Debugger::checkSecurityKeys(); ?>
+<header>
+    <div class="container text-center">
+        <a href="https://cakephp.org/" target="_blank" rel="noopener">
+            <img alt="CakePHP" src="https://cakephp.org/v2/img/logos/CakePHP_Logo.svg" width="350"/>
+        </a>
+        <h1>
+            Welcome to CakePHP <?= h(Configure::version()) ?> Strawberry (🍓)
+        </h1>
+    </div>
+</header>
+<main class="main">
+    <div class="container">
+        <div class="content">
+            <div class="row">
+                <div class="column">
+                    <div class="message default text-center">
+                        <small>Please be aware that this page will not be shown if you turn off debug mode unless you
+                            replace templates/Pages/home.php with your own version.</small>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="column">
-                        <h4>Environment</h4>
+                    <div id="url-rewriting-warning"
+                         style="padding: 1rem; background: #fcebea; color: #cc1f1a; border-color: #ef5753;">
                         <ul>
+                            <li class="bullet problem">
+                                URL rewriting is not properly configured on your server.<br/>
+                                1) <a target="_blank" rel="noopener"
+                                      href="https://book.cakephp.org/4/en/installation.html#url-rewriting">Help me
+                                    configure it</a><br/>
+                                2) <a target="_blank" rel="noopener"
+                                      href="https://book.cakephp.org/4/en/development/configuration.html#general-configuration">I
+                                    don't / can't use URL rewriting</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <?php Debugger::checkSecurityKeys(); ?>
+                </div>
+            </div>
+            <div class="row">
+                <div class="column">
+                    <h4>Environment</h4>
+                    <ul>
                         <?php if (version_compare(PHP_VERSION, '7.4.0', '>=')) : ?>
-                            <li class="bullet success">Your version of PHP is 7.4.0 or higher (detected <?= PHP_VERSION ?>).</li>
+                            <li class="bullet success">Your version of PHP is 7.4.0 or higher
+                                (detected <?= PHP_VERSION ?>).
+                            </li>
                         <?php else : ?>
-                            <li class="bullet problem">Your version of PHP is too low. You need PHP 7.4.0 or higher to use CakePHP (detected <?= PHP_VERSION ?>).</li>
+                            <li class="bullet problem">Your version of PHP is too low. You need PHP 7.4.0 or higher to
+                                use CakePHP (detected <?= PHP_VERSION ?>).
+                            </li>
                         <?php endif; ?>
 
                         <?php if (extension_loaded('mbstring')) : ?>
                             <li class="bullet success">Your version of PHP has the mbstring extension loaded.</li>
                         <?php else : ?>
-                            <li class="bullet problem">Your version of PHP does NOT have the mbstring extension loaded.</li>
+                            <li class="bullet problem">Your version of PHP does NOT have the mbstring extension
+                                loaded.
+                            </li>
                         <?php endif; ?>
 
                         <?php if (extension_loaded('openssl')) : ?>
@@ -125,7 +139,9 @@ endif;
                         <?php elseif (extension_loaded('mcrypt')) : ?>
                             <li class="bullet success">Your version of PHP has the mcrypt extension loaded.</li>
                         <?php else : ?>
-                            <li class="bullet problem">Your version of PHP does NOT have the openssl or mcrypt extension loaded.</li>
+                            <li class="bullet problem">Your version of PHP does NOT have the openssl or mcrypt extension
+                                loaded.
+                            </li>
                         <?php endif; ?>
 
                         <?php if (extension_loaded('intl')) : ?>
@@ -133,11 +149,11 @@ endif;
                         <?php else : ?>
                             <li class="bullet problem">Your version of PHP does NOT have the intl extension loaded.</li>
                         <?php endif; ?>
-                        </ul>
-                    </div>
-                    <div class="column">
-                        <h4>Filesystem</h4>
-                        <ul>
+                    </ul>
+                </div>
+                <div class="column">
+                    <h4>Filesystem</h4>
+                    <ul>
                         <?php if (is_writable(TMP)) : ?>
                             <li class="bullet success">Your tmp directory is writable.</li>
                         <?php else : ?>
@@ -152,31 +168,36 @@ endif;
 
                         <?php $settings = Cache::getConfig('_cake_core_'); ?>
                         <?php if (!empty($settings)) : ?>
-                            <li class="bullet success">The <em><?= h($settings['className']) ?></em> is being used for core caching. To change the config edit config/app.php</li>
+                            <li class="bullet success">The <em><?= h($settings['className']) ?></em> is being used for
+                                core caching. To change the config edit config/app.php
+                            </li>
                         <?php else : ?>
-                            <li class="bullet problem">Your cache is NOT working. Please check the settings in config/app.php</li>
+                            <li class="bullet problem">Your cache is NOT working. Please check the settings in
+                                config/app.php
+                            </li>
                         <?php endif; ?>
-                        </ul>
-                    </div>
+                    </ul>
                 </div>
-                <hr>
-                <div class="row">
-                    <div class="column">
-                        <h4>Database</h4>
-                        <?php
-                        $result = $checkConnection('default');
-                        ?>
-                        <ul>
+            </div>
+            <hr>
+            <div class="row">
+                <div class="column">
+                    <h4>Database</h4>
+                    <?php
+                    $result = $checkConnection('default');
+                    ?>
+                    <ul>
                         <?php if ($result['connected']) : ?>
                             <li class="bullet success">CakePHP is able to connect to the database.</li>
                         <?php else : ?>
-                            <li class="bullet problem">CakePHP is NOT able to connect to the database.<br /><?= h($result['error']) ?></li>
+                            <li class="bullet problem">CakePHP is NOT able to connect to the
+                                database.<br/><?= h($result['error']) ?></li>
                         <?php endif; ?>
-                        </ul>
-                    </div>
-                    <div class="column">
-                        <h4>DebugKit</h4>
-                        <ul>
+                    </ul>
+                </div>
+                <div class="column">
+                    <h4>DebugKit</h4>
+                    <ul>
                         <?php if (Plugin::isLoaded('DebugKit')) : ?>
                             <li class="bullet success">DebugKit is loaded.</li>
                             <?php
@@ -185,55 +206,61 @@ endif;
                             <?php if ($result['connected']) : ?>
                                 <li class="bullet success">DebugKit can connect to the database.</li>
                             <?php else : ?>
-                                <li class="bullet problem">There are configuration problems present which need to be fixed:<br /><?= $result['error'] ?></li>
+                                <li class="bullet problem">There are configuration problems present which need to be
+                                    fixed:<br/><?= $result['error'] ?></li>
                             <?php endif; ?>
                         <?php else : ?>
                             <li class="bullet problem">DebugKit is <strong>not</strong> loaded.</li>
                         <?php endif; ?>
-                        </ul>
-                    </div>
+                    </ul>
                 </div>
-                <hr>
-                <div class="row">
-                    <div class="column links">
-                        <h3>Getting Started</h3>
-                        <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/">CakePHP Documentation</a>
-                        <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/tutorials-and-examples/cms/installation.html">The 20 min CMS Tutorial</a>
-                    </div>
+            </div>
+            <hr>
+            <div class="row">
+                <div class="column links">
+                    <h3>Getting Started</h3>
+                    <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/">CakePHP Documentation</a>
+                    <a target="_blank" rel="noopener"
+                       href="https://book.cakephp.org/4/en/tutorials-and-examples/cms/installation.html">The 20 min CMS
+                        Tutorial</a>
                 </div>
-                <hr>
-                <div class="row">
-                    <div class="column links">
-                        <h3>Help and Bug Reports</h3>
-                        <a target="_blank" rel="noopener" href="irc://irc.freenode.net/cakephp">irc.freenode.net #cakephp</a>
-                        <a target="_blank" rel="noopener" href="https://slack-invite.cakephp.org/">Slack</a>
-                        <a target="_blank" rel="noopener" href="https://github.com/cakephp/cakephp/issues">CakePHP Issues</a>
-                        <a target="_blank" rel="noopener" href="https://discourse.cakephp.org/">CakePHP Forum</a>
-                    </div>
+            </div>
+            <hr>
+            <div class="row">
+                <div class="column links">
+                    <h3>Help and Bug Reports</h3>
+                    <a target="_blank" rel="noopener" href="irc://irc.freenode.net/cakephp">irc.freenode.net
+                        #cakephp</a>
+                    <a target="_blank" rel="noopener" href="https://slack-invite.cakephp.org/">Slack</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/cakephp/cakephp/issues">CakePHP
+                        Issues</a>
+                    <a target="_blank" rel="noopener" href="https://discourse.cakephp.org/">CakePHP Forum</a>
                 </div>
-                <hr>
-                <div class="row">
-                    <div class="column links">
-                        <h3>Docs and Downloads</h3>
-                        <a target="_blank" rel="noopener" href="https://api.cakephp.org/">CakePHP API</a>
-                        <a target="_blank" rel="noopener" href="https://bakery.cakephp.org">The Bakery</a>
-                        <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/">CakePHP Documentation</a>
-                        <a target="_blank" rel="noopener" href="https://plugins.cakephp.org">CakePHP plugins repo</a>
-                        <a target="_blank" rel="noopener" href="https://github.com/cakephp/">CakePHP Code</a>
-                        <a target="_blank" rel="noopener" href="https://github.com/FriendsOfCake/awesome-cakephp">CakePHP Awesome List</a>
-                        <a target="_blank" rel="noopener" href="https://www.cakephp.org">CakePHP</a>
-                    </div>
+            </div>
+            <hr>
+            <div class="row">
+                <div class="column links">
+                    <h3>Docs and Downloads</h3>
+                    <a target="_blank" rel="noopener" href="https://api.cakephp.org/">CakePHP API</a>
+                    <a target="_blank" rel="noopener" href="https://bakery.cakephp.org">The Bakery</a>
+                    <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/en/">CakePHP Documentation</a>
+                    <a target="_blank" rel="noopener" href="https://plugins.cakephp.org">CakePHP plugins repo</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/cakephp/">CakePHP Code</a>
+                    <a target="_blank" rel="noopener" href="https://github.com/FriendsOfCake/awesome-cakephp">CakePHP
+                        Awesome List</a>
+                    <a target="_blank" rel="noopener" href="https://www.cakephp.org">CakePHP</a>
                 </div>
-                <hr>
-                <div class="row">
-                    <div class="column links">
-                        <h3>Training and Certification</h3>
-                        <a target="_blank" rel="noopener" href="https://cakefoundation.org/">Cake Software Foundation</a>
-                        <a target="_blank" rel="noopener" href="https://training.cakephp.org/">CakePHP Training</a>
-                    </div>
+            </div>
+            <hr>
+            <div class="row">
+                <div class="column links">
+                    <h3>Training and Certification</h3>
+                    <a target="_blank" rel="noopener" href="https://cakefoundation.org/">Cake Software Foundation</a>
+                    <a target="_blank" rel="noopener" href="https://training.cakephp.org/">CakePHP Training</a>
                 </div>
             </div>
         </div>
-    </main>
+    </div>
+</main>
 </body>
 </html>

--- a/templates/element/flash/default.php
+++ b/templates/element/flash/default.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var AppView $this
  * @var array $params
  * @var string $message
  */
+
+use App\View\AppView;
+
 $class = 'message';
 if (!empty($params['class'])) {
     $class .= ' ' . $params['class'];

--- a/templates/element/flash/error.php
+++ b/templates/element/flash/error.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var AppView $this
  * @var array $params
  * @var string $message
  */
+
+use App\View\AppView;
+
 if (!isset($params['escape']) || $params['escape'] !== false) {
     $message = h($message);
 }

--- a/templates/element/flash/info.php
+++ b/templates/element/flash/info.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var AppView $this
  * @var array $params
  * @var string $message
  */
+
+use App\View\AppView;
+
 if (!isset($params['escape']) || $params['escape'] !== false) {
     $message = h($message);
 }

--- a/templates/element/flash/success.php
+++ b/templates/element/flash/success.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var AppView $this
  * @var array $params
  * @var string $message
  */
+
+use App\View\AppView;
+
 if (!isset($params['escape']) || $params['escape'] !== false) {
     $message = h($message);
 }

--- a/templates/element/flash/warning.php
+++ b/templates/element/flash/warning.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var AppView $this
  * @var array $params
  * @var string $message
  */
+
+use App\View\AppView;
+
 if (!isset($params['escape']) || $params['escape'] !== false) {
     $message = h($message);
 }

--- a/templates/element/layout/footer.php
+++ b/templates/element/layout/footer.php
@@ -1,7 +1,9 @@
 <footer class="bg-dark py-4 mt-auto">
     <div class="container px-5">
         <div class="row align-items-center justify-content-between flex-column flex-sm-row">
-            <div class="col-auto"><div class="small m-0 text-white">Copyright © Your Website 2023</div></div>
+            <div class="col-auto">
+                <div class="small m-0 text-white">Copyright © Your Website 2023</div>
+            </div>
             <div class="col-auto">
                 <a class="link-light small" href="#!">Privacy</a>
                 <span class="text-white mx-1">·</span>

--- a/templates/email/html/default.php
+++ b/templates/email/html/default.php
@@ -11,9 +11,11 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \Cake\View\View $this
+ * @var View $this
  * @var string $content
  */
+
+use Cake\View\View;
 
 $lines = explode("\n", $content);
 

--- a/templates/email/html/welcome.php
+++ b/templates/email/html/welcome.php
@@ -2,12 +2,13 @@
 
 use App\Model\Entity\User;
 use App\View\AppView;
+
 /**
  * @var AppView $this
  * @var User $user
  */
 ?>
 
-Welcome <?=h($user->name)?>!
-<br />
+Welcome <?= h($user->name) ?>!
+<br/>
 Thank you for signing up with FeedbackRealm.

--- a/templates/email/text/default.php
+++ b/templates/email/text/default.php
@@ -11,8 +11,10 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \Cake\View\View $this
+ * @var View $this
  * @var string $content
  */
+
+use Cake\View\View;
 
 echo $content;

--- a/templates/email/text/welcome.php
+++ b/templates/email/text/welcome.php
@@ -2,12 +2,13 @@
 
 use App\Model\Entity\User;
 use App\View\AppView;
+
 /**
  * @var AppView $this
  * @var User $user
  */
 ?>
 
-Welcome <?=h($user->name)?>!
+Welcome <?= h($user->name) ?>!
 
 Thank you for signing up with FeedbackRealm.

--- a/templates/layout/ajax.php
+++ b/templates/layout/ajax.php
@@ -11,7 +11,9 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var AppView $this
  */
+
+use App\View\AppView;
 
 echo $this->fetch('content');

--- a/templates/layout/common/base.php
+++ b/templates/layout/common/base.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\View\AppView;
+
 /**
  * @var AppView $this
  */

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -11,8 +11,10 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var AppView $this
  */
+
+use App\View\AppView;
 
 $cakeDescription = 'CakePHP: the rapid development php framework';
 ?>
@@ -34,22 +36,22 @@ $cakeDescription = 'CakePHP: the rapid development php framework';
     <?= $this->fetch('script') ?>
 </head>
 <body>
-    <nav class="top-nav">
-        <div class="top-nav-title">
-            <a href="<?= $this->Url->build('/') ?>"><span>Cake</span>PHP</a>
-        </div>
-        <div class="top-nav-links">
-            <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/">Documentation</a>
-            <a target="_blank" rel="noopener" href="https://api.cakephp.org/">API</a>
-        </div>
-    </nav>
-    <main class="main">
-        <div class="container">
-            <?= $this->Flash->render() ?>
-            <?= $this->fetch('content') ?>
-        </div>
-    </main>
-    <footer>
-    </footer>
+<nav class="top-nav">
+    <div class="top-nav-title">
+        <a href="<?= $this->Url->build('/') ?>"><span>Cake</span>PHP</a>
+    </div>
+    <div class="top-nav-links">
+        <a target="_blank" rel="noopener" href="https://book.cakephp.org/4/">Documentation</a>
+        <a target="_blank" rel="noopener" href="https://api.cakephp.org/">API</a>
+    </div>
+</nav>
+<main class="main">
+    <div class="container">
+        <?= $this->Flash->render() ?>
+        <?= $this->fetch('content') ?>
+    </div>
+</main>
+<footer>
+</footer>
 </body>
 </html>

--- a/templates/layout/email/text/default.php
+++ b/templates/layout/email/text/default.php
@@ -11,8 +11,10 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var AppView $this
  */
+
+use App\View\AppView;
 
 echo $this->fetch('content');
 echo $this->TextEmailContent->horizontalLine();

--- a/templates/layout/error.php
+++ b/templates/layout/error.php
@@ -11,8 +11,11 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
- * @var \App\View\AppView $this
+ * @var AppView $this
  */
+
+use App\View\AppView;
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -30,10 +33,10 @@
     <?= $this->fetch('script') ?>
 </head>
 <body>
-    <div class="error-container">
-        <?= $this->Flash->render() ?>
-        <?= $this->fetch('content') ?>
-        <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
-    </div>
+<div class="error-container">
+    <?= $this->Flash->render() ?>
+    <?= $this->fetch('content') ?>
+    <?= $this->Html->link(__('Back'), 'javascript:history.back()') ?>
+</div>
 </body>
 </html>

--- a/tests/TestCase/Command/SeedDataCommandTest.php
+++ b/tests/TestCase/Command/SeedDataCommandTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Test\TestCase\Command;
 
-use App\Command\SeedDataCommand;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 


### PR DESCRIPTION
<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved formatting and readability of SQL table creation scripts for `i18n` and `sessions`.
  - Simplified type hints in `CustomBakePlugin.php` by removing fully qualified namespaces.
  - Updated PHPDoc annotations and `use` statements across various templates for consistency and simplified namespace references.
  - Adjusted HTML and PHP formatting in templates to enhance readability and maintainability.

- **Style**
  - Made minor whitespace and formatting adjustments in error templates and PHP configuration files.
  - Reformatted footer content in layout template for better visual structure.

- **Documentation**
  - Updated PHPDoc blocks to reflect simpler type hints following namespace import changes.

- **Chores**
  - Cleaned up unnecessary spaces in configuration files and test bootstrap.

- **Bug Fixes**
  - Ensured URLs in `home_old.php` template open in a new tab by adding `target="_blank"` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->